### PR TITLE
temporary bug fix for backdrop-filter safari error

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,8 +52,9 @@ nav {
         inset: 0 0 0 30%;
         flex-direction: column;
         padding: min(30vh, 10rem) 2rem;
-        background-color: hsl(0, 0%, 100%, 0.5);
-        backdrop-filter: blur(1rem);
+        background-color: white;
+        /* background-color: hsl(0, 0%, 100%, 0.5); */
+        /* backdrop-filter: blur(1rem);  */
         transform: translatex(100%);
         transition: transform 350ms ease-out;
     }   


### PR DESCRIPTION
blur background does not work with safari. temporarily changing the background to white to avoid the issue. I want to come back and fix this in the future